### PR TITLE
0.1.3

### DIFF
--- a/lib/dropmire/parser.rb
+++ b/lib/dropmire/parser.rb
@@ -31,8 +31,8 @@ module Dropmire
     end
 
     def parse_methods
-      [ :parse_address, :parse_carrot_string, :date_of_birth, :zipcode,
-        :license_class, :expiration_date, :parse_license_num ]
+      [ :parse_address, :parse_carrot_string, :parse_dates, 
+        :zipcode, :license_class, :parse_license_num ]
     end
 
     def parse_address
@@ -119,13 +119,17 @@ module Dropmire
       license_num(id_str)
     end
 
-    def expiration_date
-      str = /=[0-9]{4}/.match(@text).to_s
-      @attrs[:expiration_date] = transform_date str[1,4]
+    def parse_dates
+      str = /=[0-9]*/.match(@text).to_s
+      date_of_birth(str)
+      expiration_date(str)
     end
 
-    def date_of_birth
-      str = /=[0-9]*/.match(@text).to_s
+    def expiration_date(dob)
+      @attrs[:expiration_date] = transform_date(dob[1,4]) + "-#{dob[11,2]}"
+    end
+
+    def date_of_birth(str)
       dob = str[5,8]
       year = dob[0,4]
       month = str[3,2]

--- a/lib/dropmire/parser.rb
+++ b/lib/dropmire/parser.rb
@@ -22,10 +22,12 @@ module Dropmire
       @attrs
     end
 
+    def text
+      @text
+    end
+
     def parse
-      parse_methods.each do |method|
-        self.send method
-      end
+      parse_methods.each { |method| self.send method }
     end
 
     def parse_methods
@@ -33,8 +35,16 @@ module Dropmire
         :license_class, :expiration_date, :parse_license_num ]
     end
 
-    def address
-      /\A[%][a-zA-Z]*/.match(@text).to_s
+    def parse_address
+      addr = address(@text)
+      @attrs[:address][:state] = state(addr)
+      @attrs[:address][:city] = city(addr)
+
+      [@attrs[:address][:city], @attrs[:address][:state]]
+    end
+
+    def address(text)
+      /\A[%][a-zA-Z\s]*/.match(text).to_s
     end
 
     def state(addr)
@@ -56,14 +66,6 @@ module Dropmire
       name_string, street_string = carrot_string
       names split_name(name_string)
       street street_string
-    end
-
-    def parse_address
-      addr = address
-      @attrs[:address][:state] = state(addr)
-      @attrs[:address][:city] = city(addr)
-
-      [@attrs[:address][:city], @attrs[:address][:state]]
     end
 
     def split_name(name)

--- a/lib/dropmire/version.rb
+++ b/lib/dropmire/version.rb
@@ -1,3 +1,3 @@
 module Dropmire
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -101,7 +101,7 @@ describe Dropmire::Parser do
 
   describe "#expiration_date" do
     it "returns the correct date" do
-      expect(subject.expiration_date).to eql "2015-06"
+      expect(subject.expiration_date("=1506199306070")).to eql "2015-06-07"
     end
   end
 
@@ -114,7 +114,7 @@ describe Dropmire::Parser do
   describe "#date_of_birth" do
     context "Florida" do
       it "returns correct date_of_birth" do
-        expect(subject.date_of_birth).to eql "1993-06-07"
+        expect(subject.date_of_birth("=1506199306070")).to eql "1993-06-07"
       end
     end
   end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -11,13 +11,20 @@ describe Dropmire::Parser do
 
   describe "#address" do
     it "returns the address section" do
-      expect(subject.address).to eql "%FLTALLAHASSEE"
+      expect(subject.address(subject.instance_variable_get(:@text))).to eql "%FLTALLAHASSEE"
+    end
+
+    context "when city is two words" do
+      it "returns the address section" do
+        @demo_text2 = """%FLPALM CITY^JACOBSEN$CONNOR$ALAN^6357 SINKOLA DR^                            ?;6360101021210193207=1506199306070=?+! 323124522  E               1602                                   ECCECC00000?"""
+        expect(subject.address(@demo_text2)).to eql "%FLPALM CITY"
+      end
     end
   end
 
   describe "#state" do
     it "returns the correct state" do
-      addr = subject.address
+      addr = subject.address(subject.instance_variable_get(:@text))
 
       expect(subject.state(addr)).to eql "FL"
     end
@@ -25,7 +32,7 @@ describe Dropmire::Parser do
 
   describe "#city" do
     it "returns the correct city" do
-      addr = subject.address
+      addr = subject.address(subject.instance_variable_get(:@text))
 
       expect(subject.city(addr)).to eql "Tallahassee"
     end


### PR DESCRIPTION
- Fixed incorrect parsing of multi-word city names.
- Adds `day` to `expiration date`
- Bumped to version `0.1.3`
