### PR TITLE
0.1.4

### DIFF
--- a/lib/dropmire/identity.rb
+++ b/lib/dropmire/identity.rb
@@ -8,73 +8,16 @@ module Dropmire
 
       @attrs = p.attrs
     end
-
-    # naive method approach
-    def address
-      { street: street, city: city, state: state, zipcode: zipcode }
+    
+    def method_missing(method, *args, &block)
+      is_attr = attrs.fetch(method, nil)
+      if is_attr.nil? && !(dl_id_values.include?(method))
+        super
+      else
+        key = find_key_from_method(method)
+        attrs[key]
+      end
     end
-
-    def street
-      attrs[:address][:street]
-    end
-
-    def city
-      attrs[:address][:city]
-    end
-
-    def state
-      attrs[:address][:state]
-    end
-
-    def zipcode
-      attrs[:address][:zipcode]
-    end
-
-    def names
-      { first: first_name, middle: middle_name, last: last_name }
-    end
-
-    def first_name
-      attrs[:name][:first]
-    end
-
-    def middle_name
-      attrs[:name][:middle]
-    end
-
-    def last_name
-      attrs[:name][:last]
-    end
-
-    def drivers_license_number
-      attrs[:license_num]
-    end
-
-    def drivers_license_iin
-      attrs[:iin]
-    end
-
-    def drivers_license_class
-      attrs[:license_class]
-    end
-
-    def drivers_license_expiration_date
-      attrs[:expiration_date]
-    end
-
-    def date_of_birth
-      attrs[:date_of_birth]
-    end
-
-    # For meta attr methods later...
-    #
-    # def method_missing(method, *args, &block)
-    #   if addr_lookup method.to_s
-        
-    #   else
-    #     super
-    #   end
-    # end
 
     private
 
@@ -82,20 +25,26 @@ module Dropmire
         @attrs
       end
 
-      # def attr_lookup(attr)
-      #   if attrs.has_key? attr
-      #   elsif address_vars
-      #   elsif name_vars
-      #   else
-      #   end
-      # end
+      def dl_id_values
+        [:drivers_license_expiration_date, :drivers_license_iin,
+         :drivers_license_number]
+      end
 
-      # def address_vars
-      #   %w(street city state zipcode)
-      # end
+      def find_key_from_method(method)
+        case method.to_s
+        when 'drivers_license_expiration_date'
+          :expiration_date
+        when 'drivers_license_iin'
+          :iin
+        when 'drivers_license_number'
+          :license_num
+        else
+          method
+        end
+      end
 
-      # def name_vars
-      #   %w(first middle last first_name middle_name last_name)
-      # end
+      def drivers_license_attrs
+        %w(expiration_date iin )
+      end
   end
 end

--- a/lib/dropmire/parser.rb
+++ b/lib/dropmire/parser.rb
@@ -56,14 +56,14 @@ module Dropmire
       addr[3..l].capitalize
     end
 
-    def carrot_string
-      str = /\^(.*)\^/.match(@text).to_s
+    def carrot_string(text)
+      str = /\^(.*)\^/.match(text).to_s
       len = str.length-2
       str[1..len].split('^')
     end
 
     def parse_carrot_string
-      name_string, street_string = carrot_string
+      name_string, street_string = carrot_string(@text)
       names split_name(name_string)
       street street_string
     end
@@ -76,8 +76,15 @@ module Dropmire
       @attrs[:name] = {
         first:  names[1].capitalize,
         last:   names[0].capitalize,
-        middle: names[2].capitalize
+        middle: capitalize_or_nil(names[2])
       }
+    end
+
+    # Capitalizes and returns @name if not nil, returns nil otherwise.
+    def capitalize_or_nil(name)
+      unless name.nil?
+        name.capitalize
+      end
     end
 
     def street(street)

--- a/lib/dropmire/parser.rb
+++ b/lib/dropmire/parser.rb
@@ -15,7 +15,7 @@ module Dropmire
     # Returns the Hash of results from the string.
     def initialize(text, options = {})
       @text = text
-      @attrs = {:address=>{}} # empty hash for the parsed values
+      @attrs = {}
     end
 
     def attrs
@@ -37,10 +37,10 @@ module Dropmire
 
     def parse_address
       addr = address(@text)
-      @attrs[:address][:state] = state(addr)
-      @attrs[:address][:city] = city(addr)
+      @attrs[:state] = state(addr)
+      @attrs[:city] = city(addr)
 
-      [@attrs[:address][:city], @attrs[:address][:state]]
+      [@attrs[:city], @attrs[:state]]
     end
 
     def address(text)
@@ -73,11 +73,11 @@ module Dropmire
     end
 
     def names(names)
-      @attrs[:name] = {
-        first:  names[1].capitalize,
-        last:   names[0].capitalize,
-        middle: capitalize_or_nil(names[2])
-      }
+      @attrs[:first_name]  = names[1].capitalize
+      @attrs[:last_name]   = names[0].capitalize
+      @attrs[:middle_name] = capitalize_or_nil(names[2])
+
+      [@attrs[:first_name], @attrs[:middle_name], @attrs[:last_name]]
     end
 
     # Capitalizes and returns @name if not nil, returns nil otherwise.
@@ -93,13 +93,13 @@ module Dropmire
       ary.each do |s|
         str << s.capitalize
       end
-      @attrs[:address][:street] = str.join(' ')
+      @attrs[:street] = str.join(' ')
     end
 
     def zipcode
       str = /![\s]*[0-9]*/.match(@text).to_s
       zip = str[1..(str.length)].strip
-      @attrs[:address][:zipcode] = zip[0,5]
+      @attrs[:zipcode] = zip[0,5]
     end
 
     def license_class

--- a/lib/dropmire/version.rb
+++ b/lib/dropmire/version.rb
@@ -1,3 +1,3 @@
 module Dropmire
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/identity_spec.rb
+++ b/spec/identity_spec.rb
@@ -68,7 +68,7 @@ describe Dropmire::Identity do
 
   describe "#drivers_license_expiration_date" do
     it "returns correct value" do
-      expect(subject.drivers_license_expiration_date).to eql "2015-06"
+      expect(subject.drivers_license_expiration_date).to eql "2015-06-07"
     end
   end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -47,7 +47,8 @@ describe Dropmire::Parser do
   describe "#carrot_string" do
     it "returns the correct array" do
       carrot_arr = ["JACOBSEN$CONNOR$ALAN", "6357 SINKOLA DR"]
-      expect(subject.carrot_string).to eql carrot_arr
+      @demo_text = """%FLPALM CITY^JACOBSEN$CONNOR$ALAN^6357 SINKOLA DR^                            ?;6360101021210193207=1506199306070=?+! 323124522  E               1602                                   ECCECC00000?"""
+      expect(subject.carrot_string(@demo_text)).to eql carrot_arr
     end
   end
 
@@ -55,6 +56,17 @@ describe Dropmire::Parser do
     it "returns the correct array of strings" do
       name_hash = {first: "Connor", middle: "Alan", last: "Jacobsen"}
       expect(subject.names(%w(JACOBSEN CONNOR ALAN))).to eql name_hash
+    end
+
+    context "when middle name not present" do
+      it "returns the correct hash" do
+        @demo_text = """%FLPALM CITY^JACOBSEN$CONNOR$^6357 SINKOLA DR^                            ?;6360101021210193207=1506199306070=?+! 323124522  E               1602                                   ECCECC00000?"""
+        carrot_arr = subject.carrot_string(@demo_text)
+        name_string = carrot_arr.first
+        name_arr = subject.split_name(name_string)
+        hash = {first: "Connor", middle: nil, last: "Jacobsen"}
+        expect(subject.names(name_arr)).to eql hash
+      end
     end
   end
 

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -54,8 +54,8 @@ describe Dropmire::Parser do
 
   describe "#names" do
     it "returns the correct array of strings" do
-      name_hash = {first: "Connor", middle: "Alan", last: "Jacobsen"}
-      expect(subject.names(%w(JACOBSEN CONNOR ALAN))).to eql name_hash
+      name_arr = %w(Connor Alan Jacobsen)
+      expect(subject.names(%w(JACOBSEN CONNOR ALAN))).to eql name_arr
     end
 
     context "when middle name not present" do
@@ -64,8 +64,8 @@ describe Dropmire::Parser do
         carrot_arr = subject.carrot_string(@demo_text)
         name_string = carrot_arr.first
         name_arr = subject.split_name(name_string)
-        hash = {first: "Connor", middle: nil, last: "Jacobsen"}
-        expect(subject.names(name_arr)).to eql hash
+        val = ["Connor", nil, "Jacobsen"]
+        expect(subject.names(name_arr)).to eql val
       end
     end
   end


### PR DESCRIPTION
- Bump to version 0.1.4
- Handle blank middle names
  - adds regression spec for blank middle names
- Clean up `Identity` interface
  - use `method_missing` to avoid having to define each method in `Identity`
